### PR TITLE
Feat: RpmSnapshotExcludePackages: exclude pkgs from snapshot

### DIFF
--- a/plans/snapshot.fmf
+++ b/plans/snapshot.fmf
@@ -1,0 +1,5 @@
+summary: Tests for the 'RpmSnapshot' library
+discover:
+    how: fmf
+execute:
+    how: tmt

--- a/snapshot/README.md
+++ b/snapshot/README.md
@@ -33,6 +33,34 @@ snapshoting a reverting.
 
 # FUNCTIONS
 
+### RpmSnapshotCreate
+
+It creates snapshot with current RPM state of the system
+
+### RpmSnapshotExcludePackages
+
+It excludes some packages from snapshot
+
+### RpmSnapshotRevert
+
+It restores RPMs to the state when was the snapshot created with `RpmSnapshotCreate`.
+It installs or removes packages.
+
+### RpmSnapshotDiscard
+
+It discards snapshot. You call it after `RpmSnapshotRevert` when you no longer need the snapshot
+
+### RpmSnapshotShowDiff
+
+It show difference between snapshot and current system RPM packages.
+
+`+` symbol means the package was removed
+`-` symbol means the package was installed
+
+### RpmSnapshotLibraryLoaded
+
+This is just a callback to check if the library was loaded succesfuly
+
 # AUTHORS
 
 - Dalibor Pospisil <dapospis@redhat.com>

--- a/snapshot/lib.sh
+++ b/snapshot/lib.sh
@@ -22,9 +22,9 @@
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   library-prefix = RpmSnapshot
-#   library-version = 10
+#   library-version = 11
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-__INTERNAL_RpmSnapshot_LIB_VERSION=10
+__INTERNAL_RpmSnapshot_LIB_VERSION=11
 : <<'=cut'
 =pod
 
@@ -68,6 +68,9 @@ snapshoting a reverting.
 echo -n "loading library RpmSnapshot v$__INTERNAL_RpmSnapshot_LIB_VERSION... "
 
 
+__INTERNAL_RpmSnapshot_EXCLUDE_PKGS=""
+
+
 # __INTERNAL_RpmSnapshot_get_rpm_list ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {{{
 __INTERNAL_RpmSnapshot_get_rpm_list() {
   rpm -qa --qf "%{NAME} %{VERSION} %{RELEASE} %{ARCH} %{sourcerpm}\n" | grep -vF '(none)' | sort | uniq
@@ -83,6 +86,48 @@ __INTERNAL_RpmSnapshot_show_diff() {
 }; # end of __INTERNAL_RpmSnapshot_show_diff }}}
 
 
+# __INTERNAL_RpmSnapshot_remove_excluded_packages ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {{{
+__INTERNAL_RpmSnapshot_remove_excluded_packages()
+{
+  # Return codes:
+  #   0 - successfuly removed at least 1 package from snapshot
+  #   1 - the exclude packages list not set
+  #   2 - can not access the file with list of packages
+  #   3 - runtime error - problem accessing the snapshot packages diff file
+  #   4 - Exclude list is set, there is no runtime error. But some package not found in the snapshot
+  local packages_file="$1"
+  local pkg_not_in_snapshot=""
+
+  [ -z "$__INTERNAL_RpmSnapshot_EXCLUDE_PKGS" ] && {
+    rlLogDebug "The '__INTERNAL_RpmSnapshot_EXCLUDE_PKGS' not set"
+    return 1
+  }
+
+  ! [ -r "$packages_file" ] && {
+    rlLogError "Can not find the file '${packages_file}'"
+    return 2
+  }
+
+  local res=0
+  for pkg in $__INTERNAL_RpmSnapshot_EXCLUDE_PKGS; do
+    if grep -q -E "^[+|-]?${pkg} " "$packages_file"; then
+      # Installed programs that needs to be removed
+      if sed -i -r "/^[+|-]?${pkg} .*/d" "$packages_file"; then
+        rlLog "The package '${pkg}' removed from the snapshot restore file '$packages_file'"
+      else
+        rlLogError "Problem editing the snapshot file '${packages_file}'"
+        res=3
+      fi
+    else
+      rlLog "The package '${pkg}' not found in the snapshot restore file '${packages_file}'"
+      pkg_not_in_snapshot=1
+    fi
+  done
+  [ "$res" -eq 0 ] && [ -n "$pkg_not_in_snapshot" ] && res="4"
+  return "$res"
+}; # end of __INTERNAL_RpmSnapshot_remove_excluded_packages }}}
+
+
 # RpmSnapshotCreate ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {{{
 RpmSnapshotCreate() {
   local res=0
@@ -94,6 +139,31 @@ RpmSnapshotCreate() {
   rlLog "Snapshot is saved in RPM_SNAPSHOT='$RPM_SNAPSHOT'"
   return $res
 }; # end of RpmSnapshotCreate }}}
+
+
+# RpmSnapshotExcludePackages ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {{{
+RpmSnapshotExcludePackages() {
+  # the 1st param is a list of packages to exclude from snapshot. A list is separated by a space.
+  local exclude_pkgs="$1"
+
+  [ -z "$exclude_pkgs" ] && {
+    rlLogError "exclude list is not set"
+    return 1
+  }
+
+  __INTERNAL_RpmSnapshot_EXCLUDE_PKGS="$exclude_pkgs"
+
+  [ "$#" -ne 1 ] && {
+    # If there are more than 1 arguments we consider that user did not quoted first argument and put packages to
+    # exclude as a unique parameters when calling this function
+    shift
+    for pkg in $*; do
+      __INTERNAL_RpmSnapshot_EXCLUDE_PKGS+=" ${pkg}"
+    done
+  }
+  rlLog "Excluded packages list set"
+  rlLogDebug "$__INTERNAL_RpmSnapshot_EXCLUDE_PKGS"
+}; # end of RpmSnapshotExcludePackages }}}
 
 
 # __INTERNAL_RpmSnapshot_GetRpmPathInMnt ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {{{
@@ -156,7 +226,12 @@ RpmSnapshotRevert() {
       __INTERNAL_RpmSnapshot_show_diff $s $tmp >$tmp2
       rlLogDebug "$FUNCNAME(): diff against snapshot is `cat $tmp2`"
       grep '^+' $tmp2 | sed -e 's/^.\([0-9]\+:\)\?//' >$remove
+      __INTERNAL_RpmSnapshot_remove_excluded_packages "$remove"
+      rlLogDebug "$FUNCNAME(): remove pkgs: `cat $remove`"
       grep '^-' $tmp2 | sed -e 's/^.\([0-9]\+:\)\?//' >$tmp
+      __INTERNAL_RpmSnapshot_remove_excluded_packages "$tmp"
+      rlLogDebug "$FUNCNAME(): install pkgs: `cat $tmp`"
+
       rlLogDebug "$FUNCNAME(): for inspection `cat $tmp`"
       cat $tmp | while IFS=' ' read N V R A SRC; do
         rlLogDebug "$FUNCNAME(): checking $N $V $R $A, source package $SRC"
@@ -217,6 +292,8 @@ RpmSnapshotRevert() {
       }
       rlLog "Check state after restore"
       __INTERNAL_RpmSnapshot_get_rpm_list > $tmp
+      __INTERNAL_RpmSnapshot_remove_excluded_packages "$s"
+      __INTERNAL_RpmSnapshot_remove_excluded_packages "$tmp"
       ! __INTERNAL_RpmSnapshot_show_diff $s $tmp || let res++
       rm -rf $tmpdir
   else
@@ -233,6 +310,7 @@ RpmSnapshotDiscard() {
   local res=0
   [[ -z "$1" ]] && unset RPM_SNAPSHOT
   if [[ -r "$s" ]]; then
+    unset __INTERNAL_RpmSnapshot_EXCLUDE_PKGS
     rm -f $s
   else
     rlLogError "No snapshot available!"

--- a/tests/exclude_list_after/main.fmf
+++ b/tests/exclude_list_after/main.fmf
@@ -1,0 +1,4 @@
+summary: Tests setting exclude list before RpmSnapshotCreate
+test: ./test.sh
+framework: beakerlib
+duration: 5m

--- a/tests/exclude_list_after/test.sh
+++ b/tests/exclude_list_after/test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup "Install lib, programs setup"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+        rlRun "rlImport snapshot"
+
+        rlRun "yum remove -y mc tmux" 0 "Make sure there are not 2 programs that we plan to use for this test"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Create snapshot"
+        exclude_list="mc tmux"
+        rlRun "RpmSnapshotExcludePackages '${exclude_list}'"
+        rlRun "RpmSnapshotCreate"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Install packages"
+        rlRun "RpmSnapshotShowDiff"
+        rlRun "yum install -y mc tmux"
+        rlRun "RpmSnapshotShowDiff"    
+    rlPhaseEnd
+
+    rlPhaseStartTest "Snapshot revert"
+        rlRun "RpmSnapshotRevert" 0 "Do not remove packages"
+        rlRun "RpmSnapshotDiscard"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Checking system programs"
+        rlRun "rpm -q mc" 0 "The package 'mc' should be kept installed"
+        rlRun "rpm -q tmux" 0 "The package 'tmux' should be kept installed"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "yum remove -y mc tmux" 0 "Remove leftover packages"
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/exclude_list_after02/main.fmf
+++ b/tests/exclude_list_after02/main.fmf
@@ -1,0 +1,4 @@
+summary: Tests setting exclude list before RpmSnapshotCreate - Something keep, something uninstall
+test: ./test.sh
+framework: beakerlib
+duration: 5m

--- a/tests/exclude_list_after02/test.sh
+++ b/tests/exclude_list_after02/test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+
+rlJournalStart
+    rlPhaseStartSetup "Install lib, programs setup"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+        rlRun "rlImport snapshot"
+
+        rlRun "yum install -y mc tmux" 0 "Make sure there are not 2 programs that we plan to use for this test"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Create snapshot"
+        exclude_list="tmux"
+        rlRun "RpmSnapshotCreate"
+        rlRun "RpmSnapshotExcludePackages '${exclude_list}'"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Install packages"
+        rlRun "RpmSnapshotShowDiff"
+        rlRun "yum remove -y mc tmux"
+        rlRun "RpmSnapshotShowDiff"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Snapshot restore"
+        rlRun "RpmSnapshotRevert" 0 "should install only 'mc'"
+        rlRun "RpmSnapshotDiscard"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Checking system programs"
+        rlRun "rpm -q mc" 0 "The package 'mc' should be installed"
+        rlRun "rpm -q tmux" 1 "The package 'tmux' should be kept uninstalled"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "yum remove -y mc tmux" 0 "Remove leftover packages"
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/exclude_list_before/main.fmf
+++ b/tests/exclude_list_before/main.fmf
@@ -1,0 +1,4 @@
+summary: Tests setting exclude list before RpmSnapshotCreate
+test: ./test.sh
+framework: beakerlib
+duration: 5m

--- a/tests/exclude_list_before/test.sh
+++ b/tests/exclude_list_before/test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+
+rlJournalStart
+    rlPhaseStartSetup "Install lib, programs setup"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+
+        rlRun "rlImport snapshot"
+
+        rlRun "yum remove -y mc tmux" 0 "Make sure there are not 2 programs that we plan to use for this test"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Create snapshot"
+        exclude_list="mc tmux"
+        rlRun "RpmSnapshotExcludePackages '${exclude_list}'"
+        rlRun "RpmSnapshotCreate"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Install packages"
+        rlRun "RpmSnapshotShowDiff"
+        rlRun "yum install -y mc tmux"
+        rlRun "RpmSnapshotShowDiff"    
+    rlPhaseEnd
+
+    rlPhaseStartTest "Snapshot restore"
+        rlRun "RpmSnapshotRevert" 0 "Do not remove packages"
+        rlRun "RpmSnapshotDiscard"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Checking system programs"
+        rlRun "rpm -q mc" 0 "The package 'mc' should be kept installed"
+        rlRun "rpm -q tmux" 0 "The package 'tmux' should be kept installed"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "yum remove -y mc tmux" 0 "Remove leftover packages"
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/exclude_list_before02/main.fmf
+++ b/tests/exclude_list_before02/main.fmf
@@ -1,0 +1,4 @@
+summary: Tests setting exclude list before RpmSnapshotCreate
+test: ./test.sh
+framework: beakerlib
+duration: 5m

--- a/tests/exclude_list_before02/test.sh
+++ b/tests/exclude_list_before02/test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup "Install lib, programs setup"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+
+        rlRun "rlImport snapshot"
+
+        rlRun "yum install -y mc tmux" 0 "Install 2 programs that we plan to use for this test"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Create snapshot"
+        exclude_list="mc tmux"
+        rlRun "RpmSnapshotExcludePackages '${exclude_list}'"
+        rlRun "RpmSnapshotCreate"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Remove packages"
+        rlRun "RpmSnapshotShowDiff"
+        rlRun "yum remove -y mc tmux"
+        rlRun "RpmSnapshotShowDiff"    
+    rlPhaseEnd
+
+    rlPhaseStartTest "Snapshot restore"
+        rlRun "RpmSnapshotRevert" 0 "Should install back both 'tmux' and 'mc'"
+        rlRun "RpmSnapshotDiscard"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Checking system programs"
+        rlRun "rpm -q mc" 1 "The package 'mc' should be kept removed"
+        rlRun "rpm -q tmux" 1 "The package 'tmux' should be kept removed"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "yum remove -y mc tmux" 0 "Remove leftover packages"
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/exclude_params_after/main.fmf
+++ b/tests/exclude_params_after/main.fmf
@@ -1,0 +1,4 @@
+summary: Tests setting exclude parameters after RpmSnapshotCreate
+test: ./test.sh
+framework: beakerlib
+duration: 5m

--- a/tests/exclude_params_after/test.sh
+++ b/tests/exclude_params_after/test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+
+rlJournalStart
+    rlPhaseStartSetup "Install lib, programs setup"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+        rlRun "rlImport snapshot"
+
+        rlRun "yum install -y mc tmux" 0 "Install 2 programs that we plan to use for this test"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Create snapshot"
+        exclude_params="mc tmux"
+        rlRun "RpmSnapshotExcludePackages ${exclude_params}"
+        rlRun "RpmSnapshotCreate"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Removing 2 programs"
+        rlRun "RpmSnapshotShowDiff"
+        rlRun "yum remove -y mc tmux"
+        rlRun "RpmSnapshotShowDiff"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Snapshot restore"
+        rlRun "RpmSnapshotRevert" 0 "keep both 'tmux' and 'mc' removed"
+        rlRun "RpmSnapshotDiscard"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Checking system programs"
+        rlRun "rpm -q mc" 1 "The package 'mc' should be kept uninstalled"
+        rlRun "rpm -q tmux" 1 "The package 'tmux' should be kept uninstalled"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "yum remove -y mc tmux" 0 "Remove leftover packages"
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/exclude_params_before/main.fmf
+++ b/tests/exclude_params_before/main.fmf
@@ -1,0 +1,4 @@
+summary: Tests setting exclude parameters before RpmSnapshotCreate
+test: ./test.sh
+framework: beakerlib
+duration: 5m

--- a/tests/exclude_params_before/test.sh
+++ b/tests/exclude_params_before/test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+
+rlJournalStart
+    rlPhaseStartSetup "Install lib, programs setup"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+        rlRun "rlImport snapshot"
+
+        rlRun "yum remove -y mc tmux" 0 "Install 2 programs that we plan to use for this test"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Create snapshot"
+        exclude_params="mc tmux"
+        rlRun "RpmSnapshotExcludePackages ${exclude_params}"
+        rlRun "RpmSnapshotCreate"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Removing 2 programs"
+        rlRun "RpmSnapshotShowDiff"
+        rlRun "yum install -y mc tmux"
+        rlRun "RpmSnapshotShowDiff"    
+    rlPhaseEnd
+
+    rlPhaseStartTest "Snapshot restore"
+        rlRun "RpmSnapshotRevert" 0 "Don not uninstall 'tmux' and 'mc'"
+        rlRun "RpmSnapshotDiscard"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Checking system programs"
+        rlRun "rpm -q mc" 0 "The package 'mc' should be kept installed"
+        rlRun "rpm -q tmux" 0 "The package 'tmux' should be kept installed"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "yum remove -y mc tmux" 0 "Remove leftover packages"
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/sanity_basic_install/main.fmf
+++ b/tests/sanity_basic_install/main.fmf
@@ -1,0 +1,4 @@
+summary: Sanity check for basic RpmSnapshot features - install
+test: ./test.sh
+framework: beakerlib
+duration: 5m

--- a/tests/sanity_basic_install/test.sh
+++ b/tests/sanity_basic_install/test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+
+rlJournalStart
+    rlPhaseStartSetup "Install lib, programs setup"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+        rlRun "rlImport snapshot"
+
+        rlRun "yum remove -y mc tmux" 0 "Make sure there are not 2 programs that we plan to use for this test"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Create snapshot"
+        rlRun "RpmSnapshotCreate"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Showing difference before and after install"
+        rlRun "RpmSnapshotShowDiff"
+        rlRun "yum install -y mc tmux"
+        rlRun "RpmSnapshotShowDiff"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Snapshot revert"
+        rlRun "RpmSnapshotRevert" 0 "Uninstall 'mc' and 'tmux'"
+        rlRun "RpmSnapshotDiscard"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Checking system programs"
+        rlRun "rpm -q mc" 1 "The package 'mc' should be uninstalled"
+        rlRun "rpm -q tmux" 1 "The package 'tmux' should be uninstalled"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "yum remove -y tmux mc" 0 "Remove leftover packages"
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/sanity_basic_remove/main.fmf
+++ b/tests/sanity_basic_remove/main.fmf
@@ -1,0 +1,4 @@
+summary: Sanity check for basic RpmSnapshot features - remove
+test: ./test.sh
+framework: beakerlib
+duration: 5m

--- a/tests/sanity_basic_remove/test.sh
+++ b/tests/sanity_basic_remove/test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+
+rlJournalStart
+    rlPhaseStartSetup "Install lib, programs setup"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+        rlRun "rlImport snapshot"
+
+        rlRun "yum remove -y mc tmux" 0 "Make sure there are not 2 programs that we plan to use for this test"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Create snapshot"
+        rlRun "RpmSnapshotCreate"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Showing difference before and after install"
+        rlRun "RpmSnapshotShowDiff"
+        rlRun "yum install -y mc tmux"
+        rlRun "RpmSnapshotShowDiff"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Snapshot restore"
+        rlRun "RpmSnapshotRevert" 0 "Uninstall 'mc' and 'tmux'"
+        rlRun "RpmSnapshotDiscard"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Checking system programs"
+        rlRun "rpm -q mc" 1 "The package 'mc' should be uninstalled"
+        rlRun "rpm -q tmux" 1 "The package 'tmux' should be uninstalled"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "yum remove -y tmux mc" 0 "Remove leftover packages"
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/sanity_diff/main.fmf
+++ b/tests/sanity_diff/main.fmf
@@ -1,0 +1,4 @@
+summary: Sanity check for basic RpmSnapshot features - diff between snapshot and system
+test: ./test.sh
+framework: beakerlib
+duration: 5m

--- a/tests/sanity_diff/test.sh
+++ b/tests/sanity_diff/test.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+
+rlJournalStart
+    rlPhaseStartSetup "Install lib, programs setup"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+        rlRun "rlImport snapshot"
+
+        rlRun "yum remove -y mc tmux" 0 "Make sure there are not 2 programs that we plan to use for this test"
+        rlRun "yum install -y mc" 0 "Make sure there are not 2 programs that we plan to use for this test"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Show diff before snapshot"
+        rlRun "RpmSnapshotShowDiff" 0 "Diff prints message to log when there is no snapshot"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Create snapshot"
+        rlRun "RpmSnapshotCreate"
+        diff_before_install="$( RpmSnapshotShowDiff )"
+        rlLog "diff_before_install is:"
+        echo "$diff_before_install"
+        if [[ "$diff_before_install" == "" ]]; then
+            rlPass "'diff_before_install' is empty"
+        else
+            rlLogError "'diff_before_install' should be empty"
+        fi
+    rlPhaseEnd
+
+    rlPhaseStartTest "Install tmux"
+        declare -r diff_tmuxIN="diff_tmuxIN.txt"
+        declare -i diff_tmuxIN_count
+        rlRun "yum install -y tmux"
+        rlRun "RpmSnapshotShowDiff"
+        rlRun "RpmSnapshotShowDiff > ${diff_tmuxIN}"
+
+        rlAssertGrep "^\+tmux " "$diff_tmuxIN" -E
+
+        diff_tmuxIN_count="$( wc -l ${diff_tmuxIN} | cut -d' ' -f1 )"
+        if [[ "$diff_tmuxIN_count" == "1" ]]; then
+            rlPass "There is 1 different line returned by 'RpmSnapshotDiff'"
+        else
+            rlFail "There are '${diff_tmuxIN_count}' different lines of number returned by 'RpmSnapshotDiff'"
+        fi
+    rlPhaseEnd
+
+    rlPhaseStartTest "Remove mc and keep tmux installed"
+        declare -r diff_mcRM_tmuxIN="diff_mcRM_tmuxIN.txt"
+        declare -i diff_mcRM_tmuxIN_count
+        rlRun "yum rm -y mc"
+        rlRun "RpmSnapshotShowDiff"
+        rlRun "RpmSnapshotShowDiff > ${diff_mcRM_tmuxIN}"
+
+        rlAssertGrep "^\+tmux " "$diff_mcRM_tmuxIN" -E
+        rlAssertGrep "^\-mc " "$diff_mcRM_tmuxIN" -E
+
+        diff_mcRM_tmuxIN_count="$( wc -l ${diff_mcRM_tmuxIN} | cut -d' ' -f1 )"
+        if [[ "$diff_mcRM_tmuxIN_count" == "2" ]]; then
+            rlPass "There are 2 different line returned by 'RpmSnapshotDiff'"
+        else
+            rlFail "There are '${diff_tmuxIN_count}' different lines of number returned by 'RpmSnapshotDiff'"
+        fi
+    rlPhaseEnd
+
+    rlPhaseStartTest "Install mc and remove tmux - default state before test"
+        declare -r diff_mcIN_tmuxRM="diff_mcIN_tmuxRM.txt"
+        rlRun "yum install -y mc"
+        rlRun "yum rm -y tmux"
+        rlRun "RpmSnapshotShowDiff"
+        rlRun "RpmSnapshotShowDiff > ${diff_mcIN_tmuxRM}"
+
+        if [[ "$( cat ${diff_mcIN_tmuxRM} )" == "" ]]; then
+            rlPass "'RpmSnapshotShowDiff' is empty"
+        else
+            rlLogError "'RpmSnapshotShowDiff' should be empty"
+        fi
+    rlPhaseEnd
+
+    rlPhaseStartTest "Snapshot revert"
+        rlRun "RpmSnapshotRevert" 0 "Uninstall 'mc' and 'tmux'"
+        rlRun "RpmSnapshotDiscard"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "yum remove -y tmux mc" 0 "Remove leftover packages"
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+rlJournalEnd


### PR DESCRIPTION
### Introduction

I impelented `RpmSnapshotExcludePackages` functionality. For more context see #2 

### Preparation

Install `beakerlib` and `RpmSnapshot`

```
yum install 'library(distribution/RpmSnapshot)' --enablerepo=beaker-tasks
```

### How was this feature tested

On `CentOS 6` and `CentosStream-9`

I prepared tests for it.

To run it on `C6` you should install `screen` instead of `tmux`.
```
sed -i "s/tmux/screen/g" test_ExcludePackages.sh
```

### Parameters to run test

```
NEW_LIB_PATH="lib_new.sh" bash test_ExcludePackages.sh
```

You can execute just some test, to do this use this variable and do not forget a space at the end
```
TEST_LIST='5 6 ' bash test_ExcludePackages.sh
```


**test_ExcludePackages.sh**
```
#!/bin/bash

. /usr/share/beakerlib/beakerlib.sh || exit 1

# Patching lib with new version of the lib 'RpmSnapshot'
set -x
declare -r NEW_LIB_PATH="${NEW_LIB_PATH:-lib.sh}"
declare -r ORIGINAL_LIB_PATH="${ORIGINAL_LIB_PATH:-/mnt/tests/distribution/Library/RpmSnapshot/lib.sh}"
# If you limit executed test with ENV var 'TEST_LIST' do not forget to have space at the end of each test number
#    even on the end
declare -r TEST_LIST="${TEST_LIST:-1 2 3 4 5 6 7 8 }"
set +x




grep -q "1 " <<< "$TEST_LIST" && {
echo "Test 1 - set exclude list before 'RpmSnapshotCreate'"
echo "Make sure there are not 2 programs that we plan to use for this test"
yum remove -y mc tmux

rlJournalStart
  rlPhaseStartSetup "using exclustion before snapshot is created"
    rlRun "rlImport 'distribution/RpmSnapshot'"
    rlRun "cp ${NEW_LIB_PATH} ${ORIGINAL_LIB_PATH}"
    rlRun "source ${ORIGINAL_LIB_PATH}"
    exclude_list="mc tmux"
    rlRun "RpmSnapshotExcludePackages '${exclude_list}'"
    rlRun "RpmSnapshotCreate"
  rlPhaseEnd

  rlPhaseStartTest
    rlRun "RpmSnapshotShowDiff"
    rlRun "yum install -y mc tmux"
    rlRun "RpmSnapshotShowDiff"
  rlPhaseEnd

  rlPhaseStartCleanup
    rlLog "'RpmSnapshotRevert' keep 'mc' and 'tmux' installed"
    rlRun "RpmSnapshotRevert"
    rlRun "RpmSnapshotDiscard"
  rlPhaseEnd
rlJournalEnd

  declare test1_failed="" test1_runned="1"
  rpm -q mc || {
      echo "ERROR: The package 'mc' is not kept installed"
      test1_failed=1
  }
  rpm -q tmux || {
      echo "ERROR: The package 'tmux' is not kept installed"
      test1_failed=1
  }
  [ -n "$test1_failed" ] && echo " TEST FAILED" || echo " TEST PASSED"
  echo "End of 'Test 1'"
}



grep -q "2 " <<< "$TEST_LIST" && {
echo -e "\n\n\n\n\n\n\n\nTest 2 - set exclude list after 'RpmSnapshotCreate'"
echo "Remove 'mc' and 'tmux', this time those 2 packages are installed due what happened above"
yum remove -y mc tmux

rlJournalStart
  rlPhaseStartSetup "Using exclustion after snapshot is created"
    rlRun "rlImport 'distribution/RpmSnapshot'"
    rlRun "cp ${NEW_LIB_PATH} ${ORIGINAL_LIB_PATH}"
    rlRun "source ${ORIGINAL_LIB_PATH}"
    exclude_list="mc"
    rlRun "RpmSnapshotCreate"
    rlRun "RpmSnapshotExcludePackages '${exclude_list}'"
  rlPhaseEnd

  rlPhaseStartTest
    rlRun "RpmSnapshotShowDiff"
    rlRun "yum install -y mc tmux"
    rlRun "RpmSnapshotShowDiff"
  rlPhaseEnd

  rlPhaseStartCleanup
    rlLog "'RpmSnapshotRevert' should remove only 'tmux'"
    rlRun "RpmSnapshotRevert"
    rlRun "RpmSnapshotDiscard"
  rlPhaseEnd
rlJournalEnd
  declare test2_failed="" test2_runned="1"
  rpm -q mc || {
      echo "ERROR: The package 'mc' should be keep installed"
      test2_failed=1
  }
  rpm -q tmux && {
      echo "ERROR: The package 'tmux' is should be uninstalled"
      test2_failed=1
  }
  [ -n "$test2_failed" ] && echo " TEST FAILED" || echo " TEST PASSED"
  echo "End of 'Test 2'"
}



grep -q "3 " <<< "$TEST_LIST" && {
echo -e "\n\n\n\n\n\n\n\nTest 3 - exclude list before 'RpmSnapshotCreate', remove  2 pkgs and restore only mc"
echo "Remove 'mc' and 'tmux', this time those 2 packages are installed due what happened above"
yum install -y mc tmux

rlJournalStart
  rlPhaseStartSetup "Using exclustion after snapshot is created"
    rlRun "rlImport 'distribution/RpmSnapshot'"
    rlRun "cp ${NEW_LIB_PATH} ${ORIGINAL_LIB_PATH}"
    rlRun "source ${ORIGINAL_LIB_PATH}"
    exclude_list="tmux"
    rlRun "RpmSnapshotCreate"
    rlRun "RpmSnapshotExcludePackages '${exclude_list}'"
  rlPhaseEnd

  rlPhaseStartTest
    rlRun "RpmSnapshotShowDiff"
    rlRun "yum remove -y mc tmux"
    rlRun "RpmSnapshotShowDiff"
  rlPhaseEnd

  rlPhaseStartCleanup
    rlLog "'RpmSnapshotRevert' should install only 'mc'"
    rlRun "RpmSnapshotRevert"
    rlRun "RpmSnapshotDiscard"
  rlPhaseEnd
rlJournalEnd
  declare test3_failed="" test3_runned="1"
  rpm -q mc || {
      echo "ERROR: The package 'mc' should be installed"
      test3_failed=1
  }
  rpm -q tmux && {
      echo "ERROR: The package 'tmux' should be kept uninstalled"
      test3_failed=1
  }
  [ -n "$test3_failed" ] && echo " TEST FAILED" || echo " TEST PASSED"
  echo "End of 'Test 3'"
}



grep -q "4 " <<< "$TEST_LIST" && {
echo -e "\n\n\n\n\n\n\n\nTest 4 - test 2 removes'"
echo "Install 'mc' and 'tmux'"
yum install -y mc tmux

rlJournalStart
  rlPhaseStartSetup "Using exclustion after snapshot is created"
    rlRun "rlImport 'distribution/RpmSnapshot'"
    rlRun "cp ${NEW_LIB_PATH} ${ORIGINAL_LIB_PATH}"
    rlRun "source ${ORIGINAL_LIB_PATH}"
    exclude_list="tmux mc"
    rlRun "RpmSnapshotCreate"
    rlRun "RpmSnapshotExcludePackages '${exclude_list}'"
  rlPhaseEnd

  rlPhaseStartTest
    rlRun "RpmSnapshotShowDiff"
    rlRun "yum remove -y mc tmux"
    rlRun "RpmSnapshotShowDiff"
  rlPhaseEnd

  rlPhaseStartCleanup
    rlLog "'RpmSnapshotRevert' should install back both 'tmux' and 'mc'"
    rlRun "RpmSnapshotRevert"
    rlRun "RpmSnapshotDiscard"
  rlPhaseEnd
rlJournalEnd
  declare test4_failed="" test4_runned="1"
  rpm -q mc && {
      echo "ERROR: The package 'mc' should be kept removed"
      test4_failed=1
  }
  rpm -q tmux && {
      echo "ERROR: The package 'tmux' should be kept removed"
      test4_failed=1
  }
  [ -n "$test4_failed" ] && echo " TEST FAILED" || echo " TEST PASSED"
  echo "End of 'Test 4'"
}



grep -q "5 " <<< "$TEST_LIST" && {
echo -e "\n\n\n\n\n\n\n\nTest 5 - 'RpmSnapshotExcludePackages' called with multiple params insted of giving it 'quoted list'"
echo "Remove 'mc' and 'tmux'"
yum remove -y mc tmux

rlJournalStart
  rlPhaseStartSetup "Removed 'quotes' for exclusion of packages"
    rlRun "rlImport 'distribution/RpmSnapshot'"
    rlRun "cp ${NEW_LIB_PATH} ${ORIGINAL_LIB_PATH}"
    rlRun "source ${ORIGINAL_LIB_PATH}"
    exclude_list="tmux mc"
    rlRun "RpmSnapshotCreate"
    rlRun "RpmSnapshotExcludePackages ${exclude_list}"
  rlPhaseEnd

  rlPhaseStartTest
    rlRun "RpmSnapshotShowDiff"
    rlRun "yum install -y mc tmux"
    rlRun "RpmSnapshotShowDiff"
  rlPhaseEnd

  rlPhaseStartCleanup
    rlLog "'RpmSnapshotRevert' should kept both 'tmux' and 'mc' installed"
    rlRun "RpmSnapshotRevert"
    rlRun "RpmSnapshotDiscard"
  rlPhaseEnd
rlJournalEnd
  declare test5_failed="" test5_runned="1"
  rpm -q mc || {
      echo "ERROR: The package 'mc' should be installed"
      test5_failed=1
  }
  rpm -q tmux || {
      echo "ERROR: The package 'tmux' should be installed"
      test5_failed=1
  }
  [ -n "$test5_failed" ] && echo " TEST FAILED" || echo " TEST PASSED"
  echo "End of 'Test 5'"
}



grep -q "6 " <<< "$TEST_LIST" && {
echo -e "\n\n\n\n\n\n\n\nTest 6 - 'RpmSnapshotExcludePackages' called with multiple params insted of giving it 'quoted list'"
echo "Install 'mc' and 'tmux'"
yum install -y mc tmux

rlJournalStart
  rlPhaseStartSetup "Removed 'quotes' for exclusion of packages"
    rlRun "rlImport 'distribution/RpmSnapshot'"
    rlRun "cp ${NEW_LIB_PATH} ${ORIGINAL_LIB_PATH}"
    rlRun "source ${ORIGINAL_LIB_PATH}"
    exclude_list="tmux mc"
    rlRun "RpmSnapshotExcludePackages ${exclude_list}"
    rlRun "RpmSnapshotCreate"
  rlPhaseEnd

  rlPhaseStartTest
    rlRun "RpmSnapshotShowDiff"
    rlRun "yum remove -y mc tmux"
    rlRun "RpmSnapshotShowDiff"
  rlPhaseEnd

  rlPhaseStartCleanup
    rlLog "'RpmSnapshotRevert' keep both 'tmux' and 'mc' removed"
    rlRun "RpmSnapshotRevert"
    rlRun "RpmSnapshotDiscard"
  rlPhaseEnd
rlJournalEnd
  declare test6_failed="" test6_runned="1"
  rpm -q mc && {
      echo "ERROR: The package 'mc' should be kept uninstalled"
      test6_failed=1
  }
  rpm -q tmux && {
      echo "ERROR: The package 'tmux' should be ketp uninstalled"
      test6_failed=1
  }
  [ -n "$test6_failed" ] && echo " TEST FAILED" || echo " TEST PASSED"
  echo "End of 'Test 6'"
}



grep -q "7 " <<< "$TEST_LIST" && {
echo -e "\n\n\n\n\n\n\n\nTest 7 - Sanity check for basic RpmSnapshot* features - install"
echo "make sure there are not 2 programs that we plan to use for this test"
yum install -y mc tmux

rlJournalStart
  rlPhaseStartSetup "Sanity check - withou exclude list"
    rlRun "rlImport 'distribution/RpmSnapshot'"
    rlRun "cp ${NEW_LIB_PATH} ${ORIGINAL_LIB_PATH}"
    rlRun "source ${ORIGINAL_LIB_PATH}"
    rlRun "RpmSnapshotCreate"
  rlPhaseEnd

  rlPhaseStartTest
    rlRun "RpmSnapshotShowDiff"
    rlRun "yum remove -y mc tmux"
    rlRun "RpmSnapshotShowDiff"
  rlPhaseEnd

  rlPhaseStartCleanup
    rlLog "'RpmSnapshotRevert' keep 'mc' and 'tmux' installed"
    rlRun "RpmSnapshotRevert"
    rlRun "RpmSnapshotDiscard"
  rlPhaseEnd
rlJournalEnd
  declare test7_failed="" test7_runned="1"
  rpm -q mc || {
      echo "ERROR: The package 'mc' should be installed"
      test7_failed=1
  }
  rpm -q tmux || {
      echo "ERROR: The package 'tmux' should be installed"
      test7_failed=1
  }
  [ -n "$test7_failed" ] && echo " TEST FAILED" || echo " TEST PASSED"
  echo "End of 'Test 7'"
}



grep -q "8 " <<< "$TEST_LIST" && {
echo -e "\n\n\n\n\n\n\n\nTest 8 - Sanity check for basic RpmSnapshot* features - remove"
echo "make sure there are not 2 programs that we plan to use for this test"
yum remove -y mc tmux

rlJournalStart
  rlPhaseStartSetup "Sanity check - withou exclude list"
    rlRun "rlImport 'distribution/RpmSnapshot'"
    rlRun "cp ${NEW_LIB_PATH} ${ORIGINAL_LIB_PATH}"
    rlRun "source ${ORIGINAL_LIB_PATH}"
    rlRun "RpmSnapshotCreate"
  rlPhaseEnd

  rlPhaseStartTest
    rlRun "RpmSnapshotShowDiff"
    rlRun "yum install -y mc tmux"
    rlRun "RpmSnapshotShowDiff"
  rlPhaseEnd

  rlPhaseStartCleanup
    rlLog "'RpmSnapshotRevert' keep 'mc' and 'tmux' installed"
    rlRun "RpmSnapshotRevert"
    rlRun "RpmSnapshotDiscard"
  rlPhaseEnd
rlJournalEnd
  declare test8_failed="" test8_runned="1"
  rpm -q mc && {
      echo "ERROR: The package 'mc' should be uninstalled"
      test8_failed=1
  }
  rpm -q tmux && {
      echo "ERROR: The package 'tmux' should be uninstalled"
      test8_failed=1
  }
  [ -n "$test8_failed" ] && echo " TEST FAILED" || echo " TEST PASSED"
  echo "End of 'Test 8'"
}



echo -e "\n\n\n\n\n\nRESULT OVERVIEW:\n________________"
[ -n "$test1_runned" ] && {
    [ -n "$test1_failed" ] && echo "1. TEST FAILED" || echo "1. TEST PASSED"
} || echo "1. TEST NOT_RUNNED"

[ -n "$test2_runned" ] && {
    [ -n "$test2_failed" ] && echo "2. TEST FAILED" || echo "2. TEST PASSED"
} || echo "2. TEST NOT_RUNNED"

[ -n "$test3_runned" ] && {
    [ -n "$test3_failed" ] && echo "3. TEST FAILED" || echo "3. TEST PASSED"
} || echo "3. TEST NOT_RUNNED"

[ -n "$test4_runned" ] && {
    [ -n "$test4_failed" ] && echo "4. TEST FAILED" || echo "4. TEST PASSED"
} || echo "4. TEST NOT_RUNNED"

[ -n "$test5_runned" ] && {
    [ -n "$test5_failed" ] && echo "5. TEST FAILED" || echo "5. TEST PASSED"
} || echo "5. TEST NOT_RUNNED"

[ -n "$test6_runned" ] && {
    [ -n "$test6_failed" ] && echo "6. TEST FAILED" || echo "6. TEST PASSED"
} || echo "6. TEST NOT_RUNNED"

[ -n "$test7_runned" ] && {
    [ -n "$test7_failed" ] && echo "7. TEST FAILED" || echo "7. TEST PASSED"
} || echo "7. TEST NOT_RUNNED"

[ -n "$test8_runned" ] && {
    [ -n "$test8_failed" ] && echo "8. TEST FAILED" || echo "8. TEST PASSED"
} || echo "8. TEST NOT_RUNNED"
```

Closes #2 
Closes #4 